### PR TITLE
Upgrade netopeer2 & friends to latest release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ clone-or-update:
 # keys being the project names and the values being the git commit hash or
 # branch name. If the branch name is not defined for a project, the default is
 # to use the branch name from the top level dictionary.
-PIN_NAME?=2024-01-16
+PIN_NAME?=2024-09-13
 clone-deps:
 	$(MAKE) clone-or-update REPOSITORY=https://github.com/CESNET/libyang.git BRANCH=$(shell jq --raw-output '."$(PIN_NAME)"."libyang" // "$(PIN_NAME)"' versions.json)
 	$(MAKE) clone-or-update REPOSITORY=https://github.com/sysrepo/sysrepo.git BRANCH=$(shell jq --raw-output '."$(PIN_NAME)"."sysrepo" // "$(PIN_NAME)"' versions.json)

--- a/versions.json
+++ b/versions.json
@@ -25,5 +25,14 @@
         "libssh": "stable-0.10",
         "libyang-python": "2.8.0",
         "sysrepo-python": "1.6.0"
+    },
+    "2024-09-13": {
+        "libyang": "v3.4.2",
+        "sysrepo": "v2.11.7",
+        "libnetconf2": "v3.5.1",
+        "netopeer2": "v2.2.31",
+        "libssh": "stable-0.10",
+        "libyang-python": "3.0.1",
+        "sysrepo-python": "1.7.2"
     }
 }


### PR DESCRIPTION
I see no significant performance regressions comparing to the version released Jan 2024.

2024-01-16:
```
make test-sysrepo
make[3]: Entering directory '/home/runner/work/notconf/notconf/fixups/yang/vendor/nokia'
podman cp ../../../../perftest/test-sysrepo.py test-yang-sros-22.2-11743497690:/
podman exec test-yang-sros-22.2-11743497690 /test-sysrepo.py --path "/nokia-state:state/chassis[chassis-class='router'][chassis-number='1']/peq[peq-slot='12']/equipped-type" -n 100
--- sysrepo 100 get_data: mean=17.744462 ms; σ=0.386090 ms ---
make[3]: Leaving directory '/home/runner/work/notconf/notconf/fixups/yang/vendor/nokia'
make test-netopeer-xpath
make[3]: Entering directory '/home/runner/work/notconf/notconf/fixups/yang/vendor/nokia'
podman run -t --rm --network container:test-yang-sros-22.2-11743497690 --name test-yang-sros-22.2-11743497690-test-netconf test-netconf -n 100 -get-data -datastore operational -namespace state=\'urn:nokia.com:sros:ns:yang:sr:state\' -filter-xpath "/state:state/chassis[chassis-class='router'][chassis-number='1']/peq[peq-slot='12']/equipped-type"
--- netopeer 100: mean=19.016931 ms σ=2.784569 ms
make[3]: Leaving directory '/home/runner/work/notconf/notconf/fixups/yang/vendor/nokia'
make test-netopeer-subtree
make[3]: Entering directory '/home/runner/work/notconf/notconf/fixups/yang/vendor/nokia'
podman run -t --rm --network container:test-yang-sros-22.2-11743497690 --name test-yang-sros-22.2-11743497690-test-netconf test-netconf -n 100 -get-data -datastore operational -filter-subtree "<state xmlns='urn:nokia.com:sros:ns:yang:sr:state'><chassis><chassis-class>router</chassis-class><chassis-number>1</chassis-number><peq><peq-slot>12</peq-slot><equipped-type/></peq></chassis></state>"
--- netopeer 100: mean=18.921654 ms σ=2.923987 ms
```

2024-09-13:
```
make test-sysrepo
make[3]: Entering directory '/home/runner/work/notconf/notconf/fixups/yang/vendor/nokia'
podman cp ../../../../perftest/test-sysrepo.py test-yang-sros-22.2-11744369449:/
podman exec test-yang-sros-22.2-11744369449 /test-sysrepo.py --path "/nokia-state:state/chassis[chassis-class='router'][chassis-number='1']/peq[peq-slot='12']/equipped-type" -n 100
--- sysrepo 100 get_data: mean=18.615056 ms; σ=0.463361 ms ---
make[3]: Leaving directory '/home/runner/work/notconf/notconf/fixups/yang/vendor/nokia'
make test-netopeer-xpath
make[3]: Entering directory '/home/runner/work/notconf/notconf/fixups/yang/vendor/nokia'
podman run -t --rm --network container:test-yang-sros-22.2-11744369449 --name test-yang-sros-22.2-11744369449-test-netconf test-netconf -n 100 -get-data -datastore operational -namespace state=\'urn:nokia.com:sros:ns:yang:sr:state\' -filter-xpath "/state:state/chassis[chassis-class='router'][chassis-number='1']/peq[peq-slot='12']/equipped-type"
--- netopeer 100: mean=19.656378 ms σ=3.205540 ms
make[3]: Leaving directory '/home/runner/work/notconf/notconf/fixups/yang/vendor/nokia'
make test-netopeer-subtree
make[3]: Entering directory '/home/runner/work/notconf/notconf/fixups/yang/vendor/nokia'
podman run -t --rm --network container:test-yang-sros-22.2-11744369449 --name test-yang-sros-22.2-11744369449-test-netconf test-netconf -n 100 -get-data -datastore operational -filter-subtree "<state xmlns='urn:nokia.com:sros:ns:yang:sr:state'><chassis><chassis-class>router</chassis-class><chassis-number>1</chassis-number><peq><peq-slot>12</peq-slot><equipped-type/></peq></chassis></state>"
--- netopeer 100: mean=20.044755 ms σ=2.870683 ms
```