### PR TITLE
Upgrade base OS to Ubuntu Noble

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,41 +29,31 @@ FROM build-tools-source AS builder
 ARG BUILD_TYPE
 
 WORKDIR /src/libyang
-RUN mkdir build && \
-  cd build && \
-  cmake -D CMAKE_BUILD_TYPE:String=${BUILD_TYPE} .. && \
-  make -j && \
-  make install
+RUN cmake -B build -D CMAKE_BUILD_TYPE:String=${BUILD_TYPE} && \
+  make -C build -j && \
+  make -C build install
 
 WORKDIR /src/sysrepo
-RUN mkdir build && \
-  cd build && \
-  # Explicitly set REPO_PATH for Debug builds
-  cmake -D CMAKE_BUILD_TYPE:String=${BUILD_TYPE} -D REPO_PATH=/etc/sysrepo .. && \
-  make -j && \
-  make install
+# Explicitly set REPO_PATH for Debug builds
+RUN cmake -B build -D CMAKE_BUILD_TYPE:String=${BUILD_TYPE} -D REPO_PATH=/etc/sysrepo && \
+  make -C build -j && \
+  make -C build install
 
 WORKDIR /src/libssh
-RUN mkdir build && \
-  cd build && \
-  cmake -D CMAKE_BUILD_TYPE:String=${BUILD_TYPE} .. && \
-  make -j && \
-  make install
+RUN cmake -B build -D CMAKE_BUILD_TYPE:String=${BUILD_TYPE} && \
+  make -C build -j && \
+  make -C build install
 
 WORKDIR /src/libnetconf2
-RUN mkdir build && \
-  cd build && \
-  cmake -D CMAKE_BUILD_TYPE:String=${BUILD_TYPE} .. && \
-  make -j && \
-  make install
+RUN cmake -B build -D CMAKE_BUILD_TYPE:String=${BUILD_TYPE} && \
+  make -C build -j && \
+  make -C build install
 
 WORKDIR /src/netopeer2
-RUN mkdir build && \
-  cd build && \
-  cmake -D CMAKE_BUILD_TYPE:String=${BUILD_TYPE} .. && \
-  make -j && \
+RUN cmake -B build -D CMAKE_BUILD_TYPE:String=${BUILD_TYPE} && \
+  make -C build -j && \
   ldconfig && \
-  make install
+  make -C build install
 
 # The notconf-release stage starts from an "empty" image and installs only the
 # bare minimum required to run the notconf applications. In general Python is

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # directories in /src. This allows us to cache this stage until the base image
 # version changes or we bump the versions of the installed packages.
 
-FROM ubuntu:jammy AS build-tools-source
+FROM ubuntu:noble AS build-tools-source
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
@@ -70,7 +70,7 @@ RUN mkdir build && \
 # not required for netopeer or sysrepo, but the current operational data loading
 # script is written in Python, so we have to install it.
 
-FROM ubuntu:jammy as notconf-release
+FROM ubuntu:noble AS notconf-release
 LABEL org.opencontainers.image.source="https://github.com/notconf/notconf"
 LABEL org.opencontainers.image.description="This is the release build of notconf. Start the container with the device YANG modules mounted to /yang-modules to simulate the NETCONF management interface."
 ARG DEBIAN_FRONTEND=noninteractive
@@ -107,7 +107,7 @@ EXPOSE 830
 CMD /run.sh
 HEALTHCHECK --start-period=30s --interval=5s CMD grep -e 'Listening on .* for SSH connections' /log/netopeer.log
 
-FROM builder as notconf-debug
+FROM builder AS notconf-debug
 LABEL org.opencontainers.image.source="https://github.com/notconf/notconf"
 LABEL org.opencontainers.image.description="This is the debug build of notconf - the server (netopeer2) and its dependencies (sysrepo, libnetconf2, libyang) are built with the debug flag set. The image also includes a compiler (clang) and debugging tools (gdb and valgrind). Start the container with the device YANG modules mounted to /yang-modules to simulate the NETCONF management interface."
 ARG SYSREPO_PYTHON_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,8 @@ RUN apt-get update \
  && apt-get install -qy libssl-dev \
  && apt-get install -qy libcurl4 \
  && apt-get install -qy python3 inotify-tools python3-pip libpcre2-dev \
+# Allow pip to "break" the distro Python for the sake of the sysrepo and libyang Python bindings
+ && find /usr/lib/python* -name EXTERNALLY-MANAGED -delete \
  && pip3 install sysrepo==${SYSREPO_PYTHON_VERSION} libyang==${LIBYANG_PYTHON_VERSION} \
  && apt-get -qy remove python3-pip libpcre2-dev \
  && apt-get -qy autoremove \
@@ -105,6 +107,8 @@ ARG LIBYANG_PYTHON_VERSION
 
 RUN apt-get update \
  && apt-get install -qy inotify-tools python3-pip \
+# Allow pip to "break" the distro Python for the sake of the sysrepo and libyang Python bindings
+ && find /usr/lib/python* -name EXTERNALLY-MANAGED -delete \
  && pip3 install netconf-console2 \
  && pip3 install sysrepo==${SYSREPO_PYTHON_VERSION} libyang==${LIBYANG_PYTHON_VERSION} \
  && apt-get -qy remove python3-pip \


### PR DESCRIPTION
Ubuntu Noble is the current LTS release. With the newer version of pip, the distro installation of Python may "protect" itself from external modifications (=installing non-distro Python packages). We're building a container image with the purpose of hosting a single app so this protection is safe to disable.