### PR TITLE
 Multi arch build for x86_64, aarch64

### DIFF
--- a/.github/workflows/build-notconf.yml
+++ b/.github/workflows/build-notconf.yml
@@ -152,3 +152,22 @@ jobs:
       with:
         name: container-logs-${{ steps.artifact-name.outputs.COMPOSE_IMAGE_NAME }}-${{ steps.artifact-name.outputs.COMPOSE_IMAGE_TAG }}
         path: container-logs/
+
+  create-manifest:
+    needs:
+    - build-notconf-base
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Log in to the container registry
+      uses: redhat-actions/podman-login@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push release manifests
+        if: ${{ github.ref_name == 'main' }}
+        run: |
+          make create-release-manifest
+          make push-release-manifest

--- a/.github/workflows/build-notconf.yml
+++ b/.github/workflows/build-notconf.yml
@@ -150,10 +150,10 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: container-logs-${{ steps.artifact-name.outputs.COMPOSE_IMAGE_NAME }}-${{ steps.artifact-name.outputs.COMPOSE_IMAGE_TAG }}
+        name: container-logs-${{ steps.artifact-name.outputs.COMPOSE_IMAGE_NAME }}-${{ steps.artifact-name.outputs.COMPOSE_IMAGE_TAG }}-${{ matrix.arch }}
         path: container-logs/
 
-  create-manifest:
+  create-base-manifest:
     needs:
     - build-notconf-base
     runs-on: ubuntu-latest
@@ -166,8 +166,39 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create and push release manifests
-        if: ${{ github.ref_name == 'main' }}
-        run: |
-          make create-release-manifest
-          make push-release-manifest
+    - name: Create and push manifests
+      run: |
+        make create-manifest
+        make push-manifest
+
+    - name: Create and push release manifests
+      if: ${{ github.ref_name == 'main' }}
+      run: |
+        make create-release-manifest
+        make push-release-manifest
+
+  create-composed-manifest:
+    if: ${{ github.ref_name == 'main' }}
+    strategy:
+      matrix:
+        path: [yang/vendor/nokia/7x50_YangModels/latest_sros_21.10,
+              yang/vendor/nokia/7x50_YangModels/latest_sros_22.2,
+              yang/vendor/juniper/21.1/21.1R1/junos,
+              yang/vendor/cisco/xr/762,
+              yang/vendor/cisco/xr/771]
+    needs:
+      - build-yangmodels
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Log in to the container registry
+      uses: redhat-actions/podman-login@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create and push release manifests
+      run: |
+        make create-release-composed-notconf-manifest YANG_PATH=${{ matrix.path }}
+        make push-release-composed-notconf-manifest YANG_PATH=${{ matrix.path }}

--- a/.github/workflows/build-notconf.yml
+++ b/.github/workflows/build-notconf.yml
@@ -12,6 +12,21 @@ permissions:
   packages: write
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      yang_paths: ${{ steps.set-yang-paths.outputs.yang_paths }}
+    steps:
+      - id: set-yang-paths
+        run: |
+          echo "yang_paths=[ \
+          \"yang/vendor/nokia/7x50_YangModels/latest_sros_21.10\", \
+          \"yang/vendor/nokia/7x50_YangModels/latest_sros_22.2\", \
+          \"yang/vendor/juniper/21.1/21.1R1/junos\", \
+          \"yang/vendor/cisco/xr/762\", \
+          \"yang/vendor/cisco/xr/771\" \
+          ]" >> $GITHUB_OUTPUT
+
   build-notconf-base:
     strategy:
       matrix:
@@ -79,16 +94,14 @@ jobs:
         path: container-logs/
 
   build-yangmodels:
+    needs:
+      - prepare
+      - build-notconf-base
     strategy:
       matrix:
-        path: [yang/vendor/nokia/7x50_YangModels/latest_sros_21.10,
-              yang/vendor/nokia/7x50_YangModels/latest_sros_22.2,
-              yang/vendor/juniper/21.1/21.1R1/junos,
-              yang/vendor/cisco/xr/762,
-              yang/vendor/cisco/xr/771]
+        path: ${{ fromJson(needs.prepare.outputs.yang_paths) }}
         arch: [x86_64, aarch64]
     runs-on: ${{ matrix.arch == 'x86_64' && 'ubuntu-latest' || 'self-hosted' }}
-    needs: build-notconf-base
 
     steps:
     - name: Set up environment
@@ -179,15 +192,12 @@ jobs:
 
   create-composed-manifest:
     if: ${{ github.ref_name == 'main' }}
+    needs:
+    - prepare
+    - build-yangmodels
     strategy:
       matrix:
-        path: [yang/vendor/nokia/7x50_YangModels/latest_sros_21.10,
-              yang/vendor/nokia/7x50_YangModels/latest_sros_22.2,
-              yang/vendor/juniper/21.1/21.1R1/junos,
-              yang/vendor/cisco/xr/762,
-              yang/vendor/cisco/xr/771]
-    needs:
-      - build-yangmodels
+        path: ${{ fromJson(needs.prepare.outputs.yang_paths) }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build-notconf.yml
+++ b/.github/workflows/build-notconf.yml
@@ -104,7 +104,7 @@ jobs:
 
     - name: Install test prerequisites
       run: |
-        pip3 install pyang
+        which pyang || pip3 install pyang
         sudo apt-get install -qy xmlstarlet
 
     - name: Cache yangmodels

--- a/.github/workflows/build-notconf.yml
+++ b/.github/workflows/build-notconf.yml
@@ -13,9 +13,15 @@ permissions:
 
 jobs:
   build-notconf-base:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+    runs-on: ${{ matrix.arch == 'x86_64' && 'ubuntu-latest' || 'self-hosted' }}
 
     steps:
+    - name: Set up environment
+      run: echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
+
     - name: Show podman info
       run: |
         podman info --format '{{ .Host.LogDriver }}'
@@ -69,11 +75,10 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: container-logs-notconf
+        name: container-logs-notconf-${{ matrix.arch }}
         path: container-logs/
 
   build-yangmodels:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         path: [yang/vendor/nokia/7x50_YangModels/latest_sros_21.10,
@@ -81,9 +86,14 @@ jobs:
               yang/vendor/juniper/21.1/21.1R1/junos,
               yang/vendor/cisco/xr/762,
               yang/vendor/cisco/xr/771]
+        arch: [x86_64, aarch64]
+    runs-on: ${{ matrix.arch == 'x86_64' && 'ubuntu-latest' || 'self-hosted' }}
     needs: build-notconf-base
 
     steps:
+    - name: Set up environment
+      run: echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
+
     - name: Show podman info
       run: |
         podman info --format '{{ .Host.LogDriver }}'

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,19 @@ create-release-manifest:
 push-release-manifest:
 	$(CONTAINER_RUNTIME) manifest push $(IMAGE_PATH)notconf:latest docker://$(IMAGE_PATH)notconf:latest
 
+# Release manifest list name for composed images is the composed image name for
+# a given YANG_PATH with stripped -$(PNS)-$(ARCH) (a.k.a. $(IMAGE_TAG)) suffix.
+# ghcr.io/notconf/notconf-junos:21.1R1-12743215247-x86_64 -> ghcr.io/notconf/notconf-junos:21.1R
+RELEASE_COMPOSED_MANIFEST_LIST_NAME = $(subst -$(IMAGE_TAG),,$(IMAGE_PATH)notconf-$(COMPOSE_IMAGE_NAME):$(COMPOSE_IMAGE_TAG))
+
+create-release-composed-notconf-manifest:
+	$(CONTAINER_RUNTIME) manifest create $(RELEASE_COMPOSED_MANIFEST_LIST_NAME)
+	$(CONTAINER_RUNTIME) manifest add $(RELEASE_COMPOSED_MANIFEST_LIST_NAME) $(IMAGE_PATH)notconf-$(COMPOSE_IMAGE_NAME):$(COMPOSE_IMAGE_TAG)-x86_64
+	$(CONTAINER_RUNTIME) manifest add $(RELEASE_COMPOSED_MANIFEST_LIST_NAME) $(IMAGE_PATH)notconf-$(COMPOSE_IMAGE_NAME):$(COMPOSE_IMAGE_TAG)-aarch64
+
+push-release-composed-notconf-manifest:
+	$(CONTAINER_RUNTIME) manifest push $(RELEASE_COMPOSED_MANIFEST_LIST_NAME)
+
 tag-release-composed-notconf: composed-notconf.txt
 	for tag in $$(uniq $<); do release_tag=$$(echo $${tag} | sed 's/-$(IMAGE_TAG)$$//'); $(CONTAINER_RUNTIME) tag $${tag} $${release_tag}; done
 

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,18 @@ push:
 	$(CONTAINER_RUNTIME) push $(IMAGE_PATH)notconf:$(IMAGE_TAG)
 	$(CONTAINER_RUNTIME) push $(IMAGE_PATH)notconf:$(IMAGE_TAG)-debug
 
+create-manifest:
+	$(CONTAINER_RUNTIME) manifest create $(IMAGE_PATH)notconf:$(IMAGE_TAG) $(IMAGE_PATH)notconf:$(IMAGE_TAG)-x86_64 $(IMAGE_PATH)notconf:$(IMAGE_TAG)-aarch64
+
+push-manifest:
+	$(CONTAINER_RUNTIME) manifest push $(IMAGE_PATH)notconf:$(IMAGE_TAG) docker://$(IMAGE_PATH)notconf:$(IMAGE_TAG)
+
+create-release-manifest:
+	$(CONTAINER_RUNTIME) manifest create $(IMAGE_PATH)notconf:latest $(IMAGE_PATH)notconf:latest-x86_64 $(IMAGE_PATH)notconf:latest-aarch64
+
+push-release-manifest:
+	$(CONTAINER_RUNTIME) manifest push $(IMAGE_PATH)notconf:latest docker://$(IMAGE_PATH)notconf:latest
+
 tag-release-composed-notconf: composed-notconf.txt
 	for tag in $$(uniq $<); do release_tag=$$(echo $${tag} | sed 's/-$(IMAGE_TAG)$$//'); $(CONTAINER_RUNTIME) tag $${tag} $${release_tag}; done
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,43 @@ Operational data sync done!
 
 ## Troubleshooting and development
 
+### Multi-arch support and building
+
+The notconf images, like `notconf` and `notconf:debug`, are manifest tags that
+combine the images for multiple architectures. The images are built for the
+following platforms:
+- linux/amd64, arch x86_64: ghcr.io/notconf/notconf:latest-x86_64
+- linux/arm64, arch aarch64: ghcr.io/notconf/notconf:latest-aarch64
+
+This means you can use the notconf images from the public registry natively on
+the supported platforms. For example, on MacOS running on Apple silicon, using
+the `ghcr.io/notconf/notconf:latest` image tag will transparently pull the
+`ghcr.io/notconf/notconf:latest-aarch64` image.
+
+The same holds true for the composed images containing vendor YANG modules. The
+version tagged image, like `notconf-junos:21.2R1`, is a manifest tag that
+combines the images for the supported architectures.
+
+```shell
+❯ docker run -it --rm ghcr.io/notconf/notconf:latest uname -m
+aarch64
+```
+
+If you start a local build, only a single image architecture - that of the build
+host, will be built. In CI we build the multi-arch images on the native platform
+hardware, i.e. for x86_64 we use the public GitHub Actions runners, and for
+aarch64 we use an ARM64 server in AWS.
+
+Building a local development image is as simple as ensuring you have installed
+the build prerequisites and running the make recipes:
+
+```shell
+# get the dependencies
+❯ make clone-deps
+# build the base images
+❯ make build
+```
+
 ## WIP and planned work
 
 - [ ] Automatically build composed images for more platforms (+ versions)


### PR DESCRIPTION
This pull request includes significant updates to the GitHub Actions workflow and the `Makefile` to support multi-architecture builds and improve CI/CD processes. The most important changes include the introduction of new jobs and steps in the workflow, modifications to the `Makefile` to handle architecture-specific image tags, and updates to the documentation to reflect these changes. Closes #9.

### Workflow and CI/CD Improvements:

* [`.github/workflows/build-notconf.yml`](diffhunk://#diff-11c46dfaf790747cff7f151f62078a717e11be7738dc9be2810660642bffef24L15-R39): Added a new `prepare` job to set up YANG paths, updated `build-notconf-base` and `build-yangmodels` jobs to support multi-architecture builds, and introduced new jobs for creating and pushing manifests (`create-base-manifest` and `create-composed-manifest`). [[1]](diffhunk://#diff-11c46dfaf790747cff7f151f62078a717e11be7738dc9be2810660642bffef24L15-R39) [[2]](diffhunk://#diff-11c46dfaf790747cff7f151f62078a717e11be7738dc9be2810660642bffef24L72-R109) [[3]](diffhunk://#diff-11c46dfaf790747cff7f151f62078a717e11be7738dc9be2810660642bffef24L97-R120) [[4]](diffhunk://#diff-11c46dfaf790747cff7f151f62078a717e11be7738dc9be2810660642bffef24L143-R214)

### Makefile Enhancements:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R33-R42): Added logic to include architecture in image tags, updated target rules to handle multi-architecture builds, and introduced new targets for creating and pushing manifests (`create-manifest`, `push-manifest`, `create-release-manifest`, `push-release-manifest`, `create-release-composed-notconf-manifest`, `push-release-composed-notconf-manifest`). [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R33-R42) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L89-R138) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L255-R311) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L291-R338)

### Documentation Update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R188-R224): Added a new section on multi-architecture support and building, explaining how the images are built and used across different platforms.